### PR TITLE
Policies added to policy page

### DIFF
--- a/app/policy/page.js
+++ b/app/policy/page.js
@@ -1,0 +1,155 @@
+import styles from "./policy.module.css";
+
+export default function Policy() {
+  return (
+    <div className={`page-content`}>
+      <div className="page-section">
+        <div className="center-aligned">
+          <p className={styles.policy}>Company Policy -- In Plain English</p>
+          <h2>Information We Collect</h2>
+          <p>
+            Information you give us, such as your phone number
+            <br /> Google Analytics. Their policy can be found at :
+            <a
+              href="https://policies.google.com/privacy?hl=en-US"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ textDecoration: "underline" }}
+            >
+              https://policies.google.com/privacy?hl=en-US
+            </a>
+          </p>
+          <br />
+          <p>That's it!</p><br/>
+
+          <h2>Terms of Service</h2>
+          <p>Our Terms of Service are brief and easy to understand!</p>
+          <br />
+          <p>
+            <strong>Invoices:</strong>
+            <br />
+            Invoices are due within 24 hours of receipt unless otherwise stated.
+            If this invoice is outstanding after 4 weeks of creation, a late fee
+            of 15%, or $15, whichever is greater, will be added every month in
+            addition to the total invoice price. Invoices outstanding past 8
+            weeks will be considered in default. Invoice may be sent to
+            collections and will incur an additional $200 collections fee; and
+            discounts on the invoice will be void. Any collections, legal, or
+            other costs associated with collecting a debt may be an added bill.
+            We offer auto-pay for all of our clients using credit or debit
+            cards.
+            <br />A 1.5% fee will be added to all card transactions; if you were
+            not informed of this fee, and you would like to have it refunded,
+            please contact us by replying to this email, by phone, or by mail.
+          </p>
+          <br />
+          <p>
+            <strong>Mitigating factors:</strong>
+            <br />
+            Factors, such as but not limited to: equipment failure, material
+            availability, weather delay or interrupt projects or services. Apex
+            Lawn Company is not responsible for unintentional damages caused by
+            service, delays, or other mitigating factors nor will it change our
+            obligations to you.
+          </p>
+          <br />
+          <p>
+            <strong>Objects on property:</strong>
+            <br />
+            Please move all mobile objects, such as but not limited to: cars,
+            hoses, and toys on the property before arrival. The work area should
+            be free of obstructions for the duration of the project or service.
+            Apex Lawn Company is not responsible to damage caused to objects
+            before, during, or after work.
+          </p>
+          <br />
+          <p>
+            <strong>Service changes:</strong>
+            <br />
+            If you have marked accept in error, please notify Apex Lawn Company
+            immediately. Overgrowth, obstacles, and inaccurate property
+            descriptions may incur additional charges determined by Apex Lawn
+            Company. Services cannot be canceled after material is purchased.
+            Changes to service date and details may be requested at the sole
+            discretion of Apex Lawn Company. If cancellation is requested after
+            certifying the service request, liability may be extended for the
+            total invoice amount.
+            <br /> Recurring services without contract require a written 30-day
+            cancellation notice by text to (919) 939-4665, email to
+            client@apexlawncompany.com, or mail to P.O. Box 1012, Apex, NC
+            27502. Contract terminations are subject to language of contract.
+          </p>
+          <br />
+          <p>
+            <strong>Underground features:</strong>
+            <br />
+            Please mark all underground features such as, but not limited to:
+            utilities and irrigation. Apex Lawn Company is not responsible for
+            damage to underground features before, during, or after work. 811
+            will mark utilities, but will not mark private features such as
+            irrigation.
+          </p>
+          <br />
+          <p>
+            <strong>Our Promise:</strong>
+            <br />
+            We strive to provide quality service to match and exceed the
+            expectations of all our clients. We cherish the opportunity you have
+            provided to earn your business, and enhance your landscape.
+          </p>
+          <br />
+          <p>Thank you — Apex Lawn Company.</p>
+          <br />
+          <h2>Termination of Contracts</h2>
+          <p>
+            <strong>
+              Termination due to bankruptcy, moving, or medical conditions:
+            </strong>
+            <br />
+            Termination due to the above special circumstances is generally
+            permitted at the discretion of Apex Lawn Company with a 30 day
+            notice for contracts with proof of circumstance.
+          </p>
+          <br />
+          <p>
+            <strong>Termination due to reasons not listed above:</strong>
+            <br /> Termination of your contract is at the discretion of an
+            authorized officer at Apex Lawn Company unless otherwise stated in
+            your contract.
+          </p>
+          <br />
+          <p>
+            <strong>
+              If you do not wish to continue services you may generally:
+            </strong>
+            <br /> a. pay 1/3 of the remaining contract balance with a minimum
+            of one service charge.
+            <br /> b. provide a 30 day notice in addition to the price of three
+            service charges.
+            <br /> Our termination clause helps us wrap up treatments for the
+            lawn, and ensure both we and the client have enough time to make the
+            adjustments required. Our contracts are desinged to get your lawn in
+            shape quick with additional investment during certain times of year.
+            They help us maintain stable prices while providing the services you
+            need based on lawn-specific and seasonal demands.
+          </p>
+          <br />
+
+          <h2>Payment</h2>
+          <p>
+            Payment by Apple Cash, AHC, and check, may be collected in advance
+            of service. Cash payments must be handed to techs on site, or be
+            left in a secure location. Apex Lawn Company is not responsible for
+            cash stolen before collection.
+            <br />​Payments by card may be collected after service, or may be
+            billed monthly. Card payments will incure a 1.5% processing fee.
+            Bounced checks and charge-backs, may incur a 15% fee no less than
+            $72. Cards stored on-file may be removed on request of client after
+            payment.
+          </p>
+          <div style={{ height: 20 }}></div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/policy/policy.module.css
+++ b/app/policy/policy.module.css
@@ -1,0 +1,3 @@
+.policy{
+    font-size: 48px;
+}


### PR DESCRIPTION
On click of policy at footer, It should navigate to policy page which will show all the company policies.
Styled according to the existing one. 

![Screenshot 2024-12-11 181839](https://github.com/user-attachments/assets/8de4ddef-99da-488c-a8c5-4e28bcab3159)
